### PR TITLE
Add Open Source Projects section to resume

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,18 @@
         strong {
             color: #34495e;
         }
+        .projects .job h3 a {
+            color: #2c3e50;
+            text-decoration: none;
+            transition: color 0.3s ease;
+        }
+        .projects .job h3 a:hover {
+            color: #3498db;
+            text-decoration: underline;
+        }
+        .projects .job p {
+            margin-bottom: 10px;
+        }
     </style>
 </head>
 <body>
@@ -246,6 +258,66 @@
                 <li>Architecture: Microservices, Domain-Driven Design (DDD), Software Design Patterns</li>
                 <li>Workflow: Argo Workflow</li>
             </ul>
+        </section>
+
+        <section class="section projects">
+            <h2>Open Source Projects</h2>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/gin-di-router" target="_blank">gin-di-router</a></h3>
+                <p class="job-title">Golang Framework Enhancement</p>
+                <p class="date">⭐ 4 stars | Language: Go</p>
+                <p>Gin framework tool that enables dependency injection for controller methods with automatic router registration, improving code maintainability and testability.</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/mcp-langfuse" target="_blank">mcp-langfuse</a></h3>
+                <p class="job-title">AI Development Tool</p>
+                <p class="date">⭐ 3 stars | Language: JavaScript</p>
+                <p>Model Context Protocol (MCP) integration for Langfuse, enabling seamless AI observability and tracing capabilities for LLM applications.</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/mcp-slack" target="_blank">mcp-slack</a></h3>
+                <p class="job-title">Communication Integration</p>
+                <p class="date">⭐ 2 stars | Language: JavaScript</p>
+                <p>Model Context Protocol server for Slack integration, allowing AI assistants to interact with Slack workspaces programmatically.</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/go-websocket" target="_blank">go-websocket</a></h3>
+                <p class="job-title">Network Communication Framework</p>
+                <p class="date">Language: Go</p>
+                <p>極輕量級的WebSocket框架，提供簡潔高效的即時通訊解決方案，適用於需要雙向通訊的應用場景。</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/gcache" target="_blank">gcache</a></h3>
+                <p class="job-title">Caching Solution</p>
+                <p class="date">⭐ 1 star | Language: Go</p>
+                <p>Lightweight in-memory cache library for Golang applications, providing efficient data caching with simple API.</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/go-clean-arch-of-echo-calendar" target="_blank">go-clean-arch-of-echo-calendar</a></h3>
+                <p class="job-title">Architecture Example</p>
+                <p class="date">Language: Go</p>
+                <p>Clean Architecture implementation using Echo framework for a calendar application, demonstrating best practices in layered architecture and separation of concerns.</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/affinity-lane" target="_blank">affinity-lane</a></h3>
+                <p class="job-title">Performance Optimization</p>
+                <p class="date">Language: Go</p>
+                <p>CPU affinity management for high-performance applications, enabling precise control over thread-to-core binding for latency-sensitive workloads.</p>
+            </div>
+
+            <div class="job">
+                <h3><a href="https://github.com/z9905080/slot-framework" target="_blank">slot-framework</a></h3>
+                <p class="job-title">Game Development</p>
+                <p class="date">Language: Go</p>
+                <p>Reusable framework for slot game development, providing core game logic and infrastructure for rapid game deployment.</p>
+            </div>
         </section>
 
     </div>


### PR DESCRIPTION
## Summary
Added a new "Open Source Projects" section to the resume showcasing 8 notable open source projects with descriptions, GitHub links, and metadata.

## Changes Made
- **New Section**: Added "Open Source Projects" section with 8 featured projects including:
  - gin-di-router (Go, 4 stars)
  - mcp-langfuse (JavaScript, 3 stars)
  - mcp-slack (JavaScript, 2 stars)
  - go-websocket (Go)
  - gcache (Go, 1 star)
  - go-clean-arch-of-echo-calendar (Go)
  - affinity-lane (Go)
  - slot-framework (Go)

- **Styling**: Added CSS rules for project links with:
  - Base color (#2c3e50) with no text decoration
  - Smooth color transition on hover (0.3s ease)
  - Hover state with blue color (#3498db) and underline
  - Improved paragraph spacing (10px margin-bottom)

## Implementation Details
- Each project entry follows the same structure as job entries (reusing `.job` class)
- Projects include GitHub links that open in new tabs
- Metadata includes star count and primary language
- Descriptions highlight key features and use cases
- One project (go-websocket) includes a Chinese description

https://claude.ai/code/session_01Gaa7XgRn5fh5CxSsCxsG4h